### PR TITLE
Configurable workflow input

### DIFF
--- a/config/publish.php
+++ b/config/publish.php
@@ -32,6 +32,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Workflow inputs
+    |--------------------------------------------------------------------------
+    |
+    | Inputs for the workflow. The inputs must be defined in the workflow file:
+    | https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
+    |
+    | An example:
+    | ['environment' => env('APP_ENV')]
+    |
+    */
+    'workflow_inputs' => [],
+
+    /*
+    |--------------------------------------------------------------------------
     | Git ref to publish
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Controllers/LastPublishRunController.php
+++ b/src/Http/Controllers/LastPublishRunController.php
@@ -23,6 +23,7 @@ class LastPublishRunController
             ->json('workflow_runs');
 
         return collect($runs)
+            ->where('conclusion', '!=', 'cancelled')
             ->sortByDesc('created_at')
             ->first();
     }

--- a/src/Http/Controllers/PublishController.php
+++ b/src/Http/Controllers/PublishController.php
@@ -24,7 +24,7 @@ class PublishController
                 config('publish.workflow_path') . '/dispatches',
                 [
                     'ref' => $ref,
-                    'inputs' => ['environment' => App::environment()],
+                    'inputs' => config('publish.workflow_inputs') ?: new \stdClass(),
                 ]
             )
             ->throw()


### PR DESCRIPTION
It's not possible to add extra inputs to the API call without defining them in de workflow. This made a workflow without the environment input fail. So now it's configurable.

The default `new \sdtClass()` is to enforce a JSON object, which Github expects when no inputs are provided.