### PR TITLE
Remove query parameter "event"

### DIFF
--- a/src/PublishManager.php
+++ b/src/PublishManager.php
@@ -22,9 +22,7 @@ class PublishManager
         $workflowPath = config('publish.workflow_path');
 
         $runs = $this->github
-            ->get("$workflowPath/runs", [
-                'event' => 'workflow_dispatch',
-            ])
+            ->get("$workflowPath/runs")
             ->throw()
             ->json('workflow_runs');
 


### PR DESCRIPTION
Somehow GitHub won't return the most recent runs with this parameter,
even though they match the `event` query.